### PR TITLE
feat(cli): add pman support command with Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ Requests managed by this plugin are tagged with `_pman.routeId`. On each sync, s
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+## CLI
+
+The package ships a small `pman` CLI:
+
+```bash
+pman help
+pman clear
+pman support
+```
+
+`pman support` prints the Discord invite: `https://discord.gg/4FBYAMxwdk`.
+
 ## License
 
 MIT

--- a/bin/pman.js
+++ b/bin/pman.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { unlink } from 'node:fs/promises';
 
+const SUPPORT_DISCORD_URL = 'https://discord.gg/4FBYAMxwdk';
+
 const cmd = process.argv[2];
 const statePath = process.argv.includes('--state')
   ? process.argv[process.argv.indexOf('--state') + 1]
@@ -11,6 +13,10 @@ if (!cmd || cmd === 'help' || cmd === '--help' || cmd === '-h') {
 
 Commands:
   pman clear [--state <path>]   Deletes the local sync state file (default .postman-sync.json)
+  pman support                  Prints the Discord support invite
+
+Support:
+  ${SUPPORT_DISCORD_URL}
 `);
   process.exit(0);
 }
@@ -29,6 +35,11 @@ if (cmd === 'clear') {
     process.stderr.write(String(e) + '\n');
     process.exit(1);
   }
+  process.exit(0);
+}
+
+if (cmd === 'support') {
+  process.stdout.write(`${SUPPORT_DISCORD_URL}\n`);
   process.exit(0);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@st3ix/pman",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@st3ix/pman",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Sync Fastify route schemas to Postman via OpenAPI and the Postman API.",
   "type": "module",
   "main": "./dist/index.js",

--- a/test/pman-cli.test.js
+++ b/test/pman-cli.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { text } from 'node:stream/consumers';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const bin = join(root, 'bin', 'pman.js');
+
+async function runPman(args) {
+  const child = spawn(process.execPath, [bin, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const outP = text(child.stdout);
+  const errP = text(child.stderr);
+  const [code] = await once(child, 'exit');
+  const out = await outP;
+  const err = await errP;
+  return { code, out, err };
+}
+
+test('pman help includes Discord support link', async () => {
+  const { code, out, err } = await runPman(['help']);
+  assert.equal(code, 0);
+  assert.equal(err, '');
+  assert.match(out, /https:\/\/discord\.gg\/4FBYAMxwdk/);
+});
+
+test('pman support prints Discord invite', async () => {
+  const { code, out, err } = await runPman(['support']);
+  assert.equal(code, 0);
+  assert.equal(err, '');
+  assert.equal(out.trim(), 'https://discord.gg/4FBYAMxwdk');
+});


### PR DESCRIPTION

## Summary
- Add `pman support` to print the Discord invite
- Extend `pman help` output with a Support section
- Document CLI usage in README
- Add CLI tests

## Test plan
- [x] `npm run lint`
- [x] `npm test`



Closes #4 