### PR TITLE
feat(plugin): add startup update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Secrets are never written to the sync state file.
 | `folderStrategy` | `path` (default), `tags`, or `hybrid` — how routes are grouped into Postman folders |
 | `folderPathStripPrefix` | Strip this URL prefix (normalized like OpenAPI) before path segments are used for folders (`path` / `hybrid`) |
 | `pathFolderNesting` | `nested` (default) or `flat` — see [Folder layout in Postman](#folder-layout-in-postman) |
+| `updateCheck` | If `true` (default), check npm for a newer `@st3ix/pman` version on startup and log an update hint |
 | `postmanApiBase` | Override Postman API base URL |
 | `fetchImpl` | Custom `fetch` (for tests) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@st3ix/pman",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@st3ix/pman",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "fastify-plugin": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@st3ix/pman",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Sync Fastify route schemas to Postman via OpenAPI and the Postman API.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/options.ts
+++ b/src/options.ts
@@ -32,6 +32,8 @@ export type FastifyPmanOptions = {
   /** When using `path` / `hybrid` path-based folders, choose single-level or nested subfolders. */
   pathFolderNesting?: PathFolderNesting;
   folderPathStripPrefix?: string;
+  /** If true (default), checks npm for a newer @st3ix/pman version on startup (logs a hint). */
+  updateCheck?: boolean;
   fetchImpl?: typeof fetch;
 };
 
@@ -48,6 +50,7 @@ export type ResolvedPmanOptions = {
   folderPathStripPrefix: string | undefined;
   reuseExistingCollectionByName: boolean;
   autoAuth: boolean;
+  updateCheck: boolean;
   auth:
     | {
         type: 'apiKey' | 'bearer';
@@ -125,6 +128,7 @@ export function resolvePmanOptions(opts: FastifyPmanOptions): ResolvedPmanOption
     folderPathStripPrefix: opts.folderPathStripPrefix,
     reuseExistingCollectionByName: opts.reuseExistingCollectionByName ?? true,
     autoAuth: opts.autoAuth ?? true,
+    updateCheck: opts.updateCheck ?? true,
     auth,
     fetchImpl: opts.fetchImpl ?? globalThis.fetch,
   };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,6 +3,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { FastifyPmanOptions } from './options.js';
 import { resolvePmanOptions } from './options.js';
 import { runPostmanSync } from './sync.js';
+import { scheduleUpdateCheck } from './update-check.js';
 
 const pluginImpl: FastifyPluginAsync<FastifyPmanOptions> = async (fastify, opts) => {
   const resolved = resolvePmanOptions(opts);
@@ -11,6 +12,7 @@ const pluginImpl: FastifyPluginAsync<FastifyPmanOptions> = async (fastify, opts)
 
   fastify.addHook('onReady', async () => {
     try {
+      scheduleUpdateCheck({ log, fetchImpl: resolved.fetchImpl, enabled: resolved.updateCheck });
       await runPostmanSync(fastify, rt);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,0 +1,88 @@
+import { readFile } from 'node:fs/promises';
+import type { FastifyBaseLogger } from 'fastify';
+
+const PKG_NAME = '@st3ix/pman';
+
+let started = false;
+
+function parseSemver(v: string): { major: number; minor: number; patch: number } | null {
+  const m = v.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+  if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) return null;
+  return { major, minor, patch };
+}
+
+function semverIsLess(a: string, b: string): boolean {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return false;
+  if (pa.major !== pb.major) return pa.major < pb.major;
+  if (pa.minor !== pb.minor) return pa.minor < pb.minor;
+  return pa.patch < pb.patch;
+}
+
+async function readInstalledVersion(): Promise<string | null> {
+  try {
+    const u = new URL('../package.json', import.meta.url);
+    const raw = await readFile(u, 'utf8');
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    const v = typeof parsed.version === 'string' ? parsed.version.trim() : '';
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLatestVersion(fetchImpl: typeof fetch): Promise<string | null> {
+  const url = `https://registry.npmjs.org/${encodeURIComponent(PKG_NAME)}`;
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), 1500);
+  try {
+    const res = await fetchImpl(url, {
+      signal: ac.signal,
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { 'dist-tags'?: { latest?: unknown } };
+    const latest = json?.['dist-tags']?.latest;
+    return typeof latest === 'string' && latest.trim() ? latest.trim() : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export function scheduleUpdateCheck(args: {
+  log: FastifyBaseLogger;
+  fetchImpl: typeof fetch;
+  enabled: boolean;
+}): void {
+  const { log, fetchImpl, enabled } = args;
+  if (!enabled) return;
+  if (started) return;
+  started = true;
+
+  // Fire-and-forget: must never block startup.
+  void (async () => {
+    const current = await readInstalledVersion();
+    if (!current) return;
+    const latest = await fetchLatestVersion(fetchImpl);
+    if (!latest) return;
+    if (!semverIsLess(current, latest)) return;
+
+    log.info(
+      {
+        current,
+        latest,
+        package: PKG_NAME,
+        update: `npm i ${PKG_NAME}@latest`,
+      },
+      'pman: update available',
+    );
+  })();
+}
+

--- a/test/update-check.test.js
+++ b/test/update-check.test.js
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('update-check registry URL encodes scoped name', () => {
+  const url = `https://registry.npmjs.org/${encodeURIComponent('@st3ix/pman')}`;
+  assert.equal(url, 'https://registry.npmjs.org/%40st3ix%2Fpman');
+});
+


### PR DESCRIPTION
## Summary
- Add an optional startup update checker that queries the npm registry for `@st3ix/pman` and logs a hint when a newer version is available.
- Default is enabled (`updateCheck: true`), can be disabled via plugin options.
- Non-blocking, short timeout, silent on failures/offline.

## Why
Keep installations current without interrupting normal Fastify startup or Postman sync, and provide a clear `npm i @st3ix/pman@latest` upgrade hint.

## Changes
- `src/update-check.ts`: background npm registry check + semver compare + log message
- `src/options.ts`: add `updateCheck` option (default `true`)
- `src/plugin.ts`: schedule the check on startup (`onReady`)
- `README.md`: document `updateCheck`
- `test/update-check.test.js`: basic coverage

## Test plan
- `npm test`
- `npm run lint`
- Manual: start an app using the plugin and verify it logs `pman: update available` when `latest > current` (or stays silent otherwise).

## Notes
- No secrets are written; the check uses the configured `fetchImpl` and never blocks startup.